### PR TITLE
squid:S2974 - Classes without public constructors should be final

### DIFF
--- a/src/main/java/com/spotify/asyncdatastoreclient/AllocateIdsResult.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/AllocateIdsResult.java
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
  *
  * Returned from a allocate ids operation.
  */
-public class AllocateIdsResult implements Result {
+public final class AllocateIdsResult implements Result {
 
   private final List<Key> keys;
 

--- a/src/main/java/com/spotify/asyncdatastoreclient/Datastore.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/Datastore.java
@@ -51,7 +51,7 @@ import java.util.zip.GZIPInputStream;
  * <p>
  * Call {@code close()} to perform all necessary clean up.
  */
-public class Datastore implements Closeable {
+public final class Datastore implements Closeable {
 
   private static final Logger log = LoggerFactory.getLogger(Datastore.class);
 

--- a/src/main/java/com/spotify/asyncdatastoreclient/DatastoreConfig.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/DatastoreConfig.java
@@ -28,7 +28,7 @@ import static com.google.common.base.MoreObjects.firstNonNull;
  * <p>
  * Defaults are assigned for any options not provided.
  */
-public class DatastoreConfig {
+public final class DatastoreConfig {
 
   private static final Integer DEFAULT_CONNECT_TIMEOUT = 5000;
   private static final Integer DEFAULT_MAX_CONNECTIONS = -1;
@@ -67,7 +67,7 @@ public class DatastoreConfig {
     this.version = firstNonNull(version, DEFAULT_VERSION);
   }
 
-  public static class Builder {
+  public static final class Builder {
     private Integer connectTimeout;
     private Integer maxConnections;
     private Integer requestTimeout;

--- a/src/main/java/com/spotify/asyncdatastoreclient/Entity.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/Entity.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
  * All properties are immutable; use {@code Entity.builder()} to construct new
  * {@code Entity} instances.
  */
-public class Entity {
+public final class Entity {
 
   private final DatastoreV1.Entity entity;
   private Map<String, Value> properties;
@@ -43,7 +43,7 @@ public class Entity {
     this.properties = null;
   }
 
-  public static class Builder {
+  public static final class Builder {
 
     private DatastoreV1.Entity.Builder entity;
     private Map<String, Value> properties;

--- a/src/main/java/com/spotify/asyncdatastoreclient/Key.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/Key.java
@@ -30,14 +30,14 @@ import java.util.stream.Collectors;
  * A key is immutable; use {@code Key.builder()} to construct new
  * {@code Key} instances.
  */
-public class Key {
+public final class Key {
 
   /**
    * Represents an key path element.
    *
    * A key path element is immutable.
    */
-  public static class Element {
+  public static final class Element {
 
     private final DatastoreV1.Key.PathElement element;
 
@@ -74,7 +74,7 @@ public class Key {
     this.key = key;
   }
 
-  public static class Builder {
+  public static final class Builder {
 
     private final DatastoreV1.Key.Builder key;
 

--- a/src/main/java/com/spotify/asyncdatastoreclient/MutationResult.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/MutationResult.java
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
  *
  * Returned from all mutation operations.
  */
-public class MutationResult implements Result {
+public final class MutationResult implements Result {
 
   private final DatastoreV1.MutationResult result;
 

--- a/src/main/java/com/spotify/asyncdatastoreclient/QueryResult.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/QueryResult.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
  *
  * Returned from query operations.
  */
-public class QueryResult implements Result, Iterable<Entity> {
+public final class QueryResult implements Result, Iterable<Entity> {
 
   private final List<Entity> entities;
   private final ByteString cursor;

--- a/src/main/java/com/spotify/asyncdatastoreclient/RollbackResult.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/RollbackResult.java
@@ -23,7 +23,7 @@ import com.google.api.services.datastore.DatastoreV1;
  *
  * Returned from a rollback operation.
  */
-public class RollbackResult implements Result {
+public final class RollbackResult implements Result {
 
   private RollbackResult() {}
 

--- a/src/main/java/com/spotify/asyncdatastoreclient/TransactionResult.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/TransactionResult.java
@@ -24,7 +24,7 @@ import com.google.protobuf.ByteString;
  *
  * Returned from a transaction operation.
  */
-public class TransactionResult implements Result {
+public final class TransactionResult implements Result {
 
   private final ByteString transaction;
 

--- a/src/main/java/com/spotify/asyncdatastoreclient/Value.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/Value.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
  * A value is immutable; use {@code Value.builder()} to construct new
  * {@code Value} instances.
  */
-public class Value {
+public final class Value {
 
   private final DatastoreV1.Value value;
 
@@ -39,7 +39,7 @@ public class Value {
     this.value = value;
   }
 
-  public static class Builder {
+  public static final class Builder {
 
     private final DatastoreV1.Value.Builder value;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2974 - Classes without "public" constructors should be "final"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2974

Please let me know if you have any questions.

M-Ezzat