### PR TITLE
Multiple quality improvements

### DIFF
--- a/src/main/java/com/spotify/asyncdatastoreclient/Datastore.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/Datastore.java
@@ -110,9 +110,9 @@ public final class Datastore implements Closeable {
     if (credential.getAccessToken() == null || expiresIn != null && expiresIn <= 60) {
       try {
         credential.refreshToken();
-        final String accessToken = credential.getAccessToken();
-        if (accessToken != null) {
-          this.accessToken = accessToken;
+        final String accessTokenLocal = credential.getAccessToken();
+        if (accessTokenLocal != null) {
+          this.accessToken = accessTokenLocal;
         }
       } catch (final IOException e) {
         log.error("Storage exception", Throwables.getRootCause(e));
@@ -120,7 +120,7 @@ public final class Datastore implements Closeable {
     }
   }
 
-  private boolean isSuccessful(final int statusCode) {
+  private static boolean isSuccessful(final int statusCode) {
     return statusCode >= 200 && statusCode < 300;
   }
 
@@ -232,11 +232,11 @@ public final class Datastore implements Closeable {
    */
   public ListenableFuture<RollbackResult> rollbackAsync(final ListenableFuture<TransactionResult> txn) {
     final ListenableFuture<Response> httpResponse = Futures.transform(txn, (TransactionResult result) -> {
-      final DatastoreV1.RollbackRequest.Builder request = DatastoreV1.RollbackRequest.newBuilder();
       final ByteString transaction = result.getTransaction();
       if (transaction == null) {
         throw new DatastoreException("Invalid transaction.");
       }
+      final DatastoreV1.RollbackRequest.Builder request = DatastoreV1.RollbackRequest.newBuilder();
       final ProtoHttpContent payload = new ProtoHttpContent(request.build());
       return ListenableFutureAdapter.asGuavaFuture(prepareRequest("rollback", payload).execute());
     });

--- a/src/main/java/com/spotify/asyncdatastoreclient/Entity.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/Entity.java
@@ -387,7 +387,7 @@ public final class Entity {
 
   @Override
   public boolean equals(final Object obj) {
-    return obj == this || (obj instanceof Entity && Objects.equals(entity, ((Entity) obj).entity));
+    return obj.getClass() == this.getClass() || (obj instanceof Entity && Objects.equals(entity, ((Entity) obj).entity));
   }
 
   DatastoreV1.Entity getPb() {
@@ -395,9 +395,7 @@ public final class Entity {
   }
 
   DatastoreV1.Entity getPb(final String namespace) {
-    final DatastoreV1.Entity.Builder prepared = DatastoreV1.Entity.newBuilder(entity)
-        .setKey(getKey().getPb(namespace));
-    final List<DatastoreV1.Property> properties = entity.getPropertyList().stream()
+    final List<DatastoreV1.Property> propertiesLocal = entity.getPropertyList().stream()
         .map(property -> {
           if (property.getValue().hasKeyValue()) {
             return DatastoreV1.Property.newBuilder(property)
@@ -406,6 +404,8 @@ public final class Entity {
           }
           return property;
         }).collect(Collectors.toList());
-    return prepared.clearProperty().addAllProperty(properties).build();
+    final DatastoreV1.Entity.Builder prepared = DatastoreV1.Entity.newBuilder(entity)
+            .setKey(getKey().getPb(namespace));
+    return prepared.clearProperty().addAllProperty(propertiesLocal).build();
   }
 }

--- a/src/main/java/com/spotify/asyncdatastoreclient/Value.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/Value.java
@@ -112,7 +112,7 @@ public final class Value {
      */
     public Builder value(final List<Object> values) {
       this.value.addAllListValue(values.stream()
-                                     .map(value -> Value.builder(value).build().getPb())
+                                     .map(valueLocal -> Value.builder(valueLocal).build().getPb())
                                      .collect(Collectors.toList()));
       return this;
     }
@@ -292,7 +292,7 @@ public final class Value {
       throw new IllegalArgumentException("Value does not contain a list.");
     }
     return ImmutableList.copyOf(value.getListValueList().stream()
-                                    .map(value -> Value.builder(value).build())
+                                    .map(valueLocal -> Value.builder(valueLocal).build())
                                     .collect(Collectors.toList()));
   }
 
@@ -305,7 +305,7 @@ public final class Value {
    */
   public <T> List<T> getList(final Class<T> clazz) {
     return ImmutableList.copyOf(getList().stream()
-                                    .map(value -> value.convert(clazz))
+                                    .map(valueLocal -> valueLocal.convert(clazz))
                                     .collect(Collectors.toList()));
   }
 
@@ -359,7 +359,7 @@ public final class Value {
 
   @Override
   public boolean equals(final Object obj) {
-    return obj == this || (obj instanceof Value && Objects.equals(value, ((Value) obj).value));
+    return obj.getClass() == this.getClass() || (obj instanceof Value && Objects.equals(value, ((Value) obj).value));
   }
 
   @Override

--- a/src/test/java/com/spotify/asyncdatastoreclient/QueryTest.java
+++ b/src/test/java/com/spotify/asyncdatastoreclient/QueryTest.java
@@ -64,7 +64,7 @@ public class QueryTest extends DatastoreTest {
     waitForConsistency();
   }
 
-  private void waitForConsistency() throws Exception {
+  private static void waitForConsistency() throws Exception {
     // Ugly hack to minimise test failures due to inconsistencies.
     // An alternative, if running locally, is to this run `gcd` with `--consistency=1.0`
     Thread.sleep(300);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:HiddenFieldCheck - Local variables should not shadow class fields
squid:S2162 - "equals" methods should be symmetric and work for subclasses
squid:S1941 - Variables should not be declared before they are relevant
squid:S2325 - "private" methods that don't access instance data should be "static"

You can find more information about the issues here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:HiddenFieldCheck
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2162
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1941
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2325

Please let me know if you have any questions.

M-Ezzat