### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/java/com/spotify/asyncdatastoreclient/QueryBuilder.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/QueryBuilder.java
@@ -28,7 +28,10 @@ import java.util.List;
  * Note that it could be convenient to use an 'import static' to use the
  * methods of this class.
  */
-public class QueryBuilder {
+public final class QueryBuilder {
+
+  private QueryBuilder(){
+  }
 
   /**
    * Start building a new INSERT query.

--- a/src/main/java/com/spotify/asyncdatastoreclient/example/Example.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/example/Example.java
@@ -40,7 +40,10 @@ import static com.spotify.asyncdatastoreclient.QueryBuilder.eq;
 /**
  * Some simple examples that should help you get started.
  */
-public class Example {
+public final class Example {
+
+  private Example() {
+  }
 
   private static void addData(final Datastore datastore) {
     final Insert insert = QueryBuilder.insert("employee", 1234567L)

--- a/src/main/java/com/spotify/asyncdatastoreclient/example/ExampleAsync.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/example/ExampleAsync.java
@@ -43,7 +43,10 @@ import static com.spotify.asyncdatastoreclient.QueryBuilder.eq;
 /**
  * Some simple asynchronous examples that should help you get started.
  */
-public class ExampleAsync {
+public final class ExampleAsync {
+
+  private ExampleAsync() {
+  }
 
   private static ListenableFuture<MutationResult> addData(final Datastore datastore) {
     final Insert insert = QueryBuilder.insert("employee", 1234567L)


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat