### PR TITLE
when property valid type is invalid, mention the name of the type

### DIFF
--- a/src/main/java/com/spotify/asyncdatastoreclient/Value.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/Value.java
@@ -100,7 +100,7 @@ public final class Value {
       } else if (value instanceof Integer) {
         this.value.setIntegerValue(((Integer) value).longValue());
       } else {
-        throw new IllegalArgumentException("Invalid value type.");
+        throw new IllegalArgumentException("Invalid value type: " + value.getClass());
       }
       return this;
     }


### PR DESCRIPTION
It would help debugging / troubleshooting to at least mention the name
of the property type.