### PR TITLE
Add support for datastore v1 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ import com.google.common.util.concurrent.ListenableFuture;
 final DatastoreConfig config = DatastoreConfig.builder()
     .requestTimeout(1000)
     .requestRetry(3)
-    .dataset(DATASET_ID)
-    .credential(DatastoreHelper.getServiceAccountCredential(ACCOUNT, KEY_PATH))
+    .project(PROJECT_ID)
+    .credential(GoogleCredential
+        .fromStream(credentialsInputStream)
+        .createScoped(DatastoreConfig.SCOPES)))
     .build();
 
 final Datastore datastore = Datastore.create(config);
@@ -95,17 +97,10 @@ mvn clean compile
 
 By default integration tests are executed against a [Local Development Server](https://cloud.google.com/datastore/docs/tools/devserver)
 on port 8080. To run tests, first download the [Development Server](https://cloud.google.com/datastore/docs/downloads)
-and create the local datastore as follows:
+and start the emulator:
 
 ```sh
-gcd.sh create -d async-test test-project
-```
-
-This will create a project called `test-project` with a dataset ID of
-`async-test`. You then start the server as follows:
-
-```sh
-gcd.sh start --consistency=1.0 test-project
+gcloud beta emulators datastore start --host-port localhost:8080 --consistency 1.0  --project async-test --data-dir project-test
 ```
 
 > NOTE: The `--consistency=1.0` option is sometimes necessary in order
@@ -120,7 +115,7 @@ mvn verify
 Properties may also be provided to override unit test configuration:
 
 ```sh
-mvn verify -Dhost=https://www.googleapis.com -Ddataset=testing -Daccount=abc@developer.gserviceaccount.com -Dkeypath=./my-key-8ae3ab23d37.p12
+mvn verify -Dhost=https://www.googleapis.com -Dproject=testing -Dkeypath=./my-key.json
 ```
 
 ## License

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.spotify</groupId>
     <artifactId>async-datastore-client</artifactId>
-    <version>1.0.5-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
 
     <parent>
         <groupId>org.sonatype.oss</groupId>
@@ -43,9 +43,8 @@
 
     <properties>
         <host>http://localhost:8080</host>
-        <dataset>async-test</dataset>
+        <project>async-test</project>
         <namespace>test</namespace>
-        <account> </account>
         <keypath> </keypath>
     </properties>
 
@@ -72,9 +71,9 @@
             <version>18.0</version>
         </dependency>
         <dependency>
-            <groupId>com.google.apis</groupId>
-            <artifactId>google-api-services-datastore-protobuf</artifactId>
-            <version>v1beta2-rev1-4.0.0</version>
+            <groupId>com.google.cloud.datastore</groupId>
+            <artifactId>datastore-v1-protos</artifactId>
+            <version>1.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -82,6 +81,16 @@
             <artifactId>junit</artifactId>
             <version>4.12</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.api-client</groupId>
+            <artifactId>google-api-client</artifactId>
+            <version>1.21.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.http-client</groupId>
+            <artifactId>google-http-client-protobuf</artifactId>
+            <version>1.15.0-rc</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/spotify/asyncdatastoreclient/AllocateIds.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/AllocateIds.java
@@ -17,7 +17,6 @@
 package com.spotify.asyncdatastoreclient;
 
 import com.google.api.client.util.Lists;
-import com.google.api.services.datastore.DatastoreV1;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -61,7 +60,7 @@ public class AllocateIds implements Statement {
     return this;
   }
 
-  List<DatastoreV1.Key> getPb(final String namespace) {
+  List<com.google.datastore.v1.Key> getPb(final String namespace) {
     return keys.stream()
         .map(key -> Key.builder(key).build().getPb(namespace))
         .collect(Collectors.toList());

--- a/src/main/java/com/spotify/asyncdatastoreclient/AllocateIdsResult.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/AllocateIdsResult.java
@@ -16,7 +16,6 @@
 
 package com.spotify.asyncdatastoreclient;
 
-import com.google.api.services.datastore.DatastoreV1;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -35,14 +34,14 @@ public final class AllocateIdsResult implements Result {
     this.keys = ImmutableList.of();
   }
 
-  private AllocateIdsResult(final List<DatastoreV1.Key> keys) {
+  private AllocateIdsResult(final List<com.google.datastore.v1.Key> keys) {
     this.keys = ImmutableList.copyOf(keys.stream()
         .map(key -> Key.builder(key).build())
         .collect(Collectors.toList()));
   }
 
-  static AllocateIdsResult build(final DatastoreV1.AllocateIdsResponse response) {
-    return new AllocateIdsResult(response.getKeyList());
+  static AllocateIdsResult build(final com.google.datastore.v1.AllocateIdsResponse response) {
+    return new AllocateIdsResult(response.getKeysList());
   }
 
   /**

--- a/src/main/java/com/spotify/asyncdatastoreclient/Batch.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/Batch.java
@@ -17,16 +17,17 @@
 package com.spotify.asyncdatastoreclient;
 
 import com.google.api.client.util.Lists;
-import com.google.api.services.datastore.DatastoreV1;
+import com.google.datastore.v1.Mutation;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * A batch mutation statement.
  *
  * Will batch a collection of mutation operations into a single operation.
  */
-public class Batch implements MutationStatement {
+public class Batch {
 
   private final List<MutationStatement> statements = Lists.newArrayList();
 
@@ -41,12 +42,11 @@ public class Batch implements MutationStatement {
     return this;
   }
 
-  @Override
-  public DatastoreV1.Mutation getPb(final String namespace) {
-    final DatastoreV1.Mutation.Builder mutation = DatastoreV1.Mutation.newBuilder();
-    for (final MutationStatement statement : statements) {
-      mutation.mergeFrom(statement.getPb(namespace));
-    }
-    return mutation.build();
+  public List<Mutation> getPb(final String namespace) {
+    return statements
+        .stream()
+        .map(m -> m.getPb(namespace))
+        .collect(Collectors.toList());
   }
+
 }

--- a/src/main/java/com/spotify/asyncdatastoreclient/DatastoreConfig.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/DatastoreConfig.java
@@ -17,6 +17,9 @@
 package com.spotify.asyncdatastoreclient;
 
 import com.google.api.client.auth.oauth2.Credential;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 
@@ -24,25 +27,28 @@ import static com.google.common.base.MoreObjects.firstNonNull;
  * Datastore configuration class used to initialise {@code Datastore}.
  * <p>
  * Use {@code DatastoreConfig.builder()} build a config object by supplying
- * options such as {@code connectTimeout()} and {@code dataset()}.
+ * options such as {@code connectTimeout()} and {@code project()}.
  * <p>
  * Defaults are assigned for any options not provided.
  */
 public final class DatastoreConfig {
 
+  public static final List<String> SCOPES = ImmutableList.of(
+    "https://www.googleapis.com/auth/datastore");
+
   private static final Integer DEFAULT_CONNECT_TIMEOUT = 5000;
   private static final Integer DEFAULT_MAX_CONNECTIONS = -1;
   private static final Integer DEFAULT_REQUEST_TIMEOUTS = 5000;
   private static final Integer DEFAULT_REQUEST_RETRIES = 5;
-  private static final String DEFAULT_HOST = "https://www.googleapis.com";
-  private static final String DEFAULT_VERSION = "v1beta2";
+  private static final String DEFAULT_HOST = "https://datastore.googleapis.com";
+  private static final String DEFAULT_VERSION = "v1";
 
   private final int connectTimeout;
   private final int maxConnections;
   private final int requestTimeout;
   private final int requestRetry;
   private final Credential credential;
-  private final String dataset;
+  private final String project;
   private final String namespace;
   private final String host;
   private final String version;
@@ -52,7 +58,7 @@ public final class DatastoreConfig {
                           final Integer requestTimeout,
                           final Integer requestRetry,
                           final Credential credential,
-                          final String dataset,
+                          final String project,
                           final String namespace,
                           final String host,
                           final String version) {
@@ -61,7 +67,7 @@ public final class DatastoreConfig {
     this.requestTimeout = firstNonNull(requestTimeout, DEFAULT_REQUEST_TIMEOUTS);
     this.requestRetry = firstNonNull(requestRetry, DEFAULT_REQUEST_RETRIES);
     this.credential = credential;
-    this.dataset = dataset;
+    this.project = project;
     this.namespace = namespace;
     this.host = firstNonNull(host, DEFAULT_HOST);
     this.version = firstNonNull(version, DEFAULT_VERSION);
@@ -73,7 +79,7 @@ public final class DatastoreConfig {
     private Integer requestTimeout;
     private Integer requestRetry;
     private Credential credential;
-    private String dataset;
+    private String project;
     private String namespace;
     private String host;
     private String version;
@@ -91,7 +97,7 @@ public final class DatastoreConfig {
                                  requestTimeout,
                                  requestRetry,
                                  credential,
-                                 dataset,
+                                 project,
                                  namespace,
                                  host,
                                  version);
@@ -160,19 +166,19 @@ public final class DatastoreConfig {
     }
 
     /**
-     * Set dataset id to use when querying Datastore.
+     * Set project id to use when querying Datastore.
      *
-     * @param dataset the dataset id.
+     * @param project the project id.
      * @return this config builder.
      */
-    public Builder dataset(final String dataset) {
-      this.dataset = dataset;
+    public Builder project(final String project) {
+      this.project = project;
       return this;
     }
 
     /**
      * An optional namespace may be specified to further partition data in
-     * your dataset.
+     * your project.
      *
      * @param namespace the namespace.
      * @return this config builder.
@@ -230,8 +236,8 @@ public final class DatastoreConfig {
     return credential;
   }
 
-  public String getDataset() {
-    return dataset;
+  public String getProject() {
+    return project;
   }
 
   public String getNamespace() {

--- a/src/main/java/com/spotify/asyncdatastoreclient/Delete.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/Delete.java
@@ -16,7 +16,7 @@
 
 package com.spotify.asyncdatastoreclient;
 
-import com.google.api.services.datastore.DatastoreV1;
+import com.google.datastore.v1.Mutation;
 
 /**
  * A delete statement.
@@ -30,8 +30,8 @@ public class Delete extends KeyedStatement implements MutationStatement {
   }
 
   @Override
-  public DatastoreV1.Mutation getPb(final String namespace) {
-    final DatastoreV1.Key mutationKey = getKey().getPb(namespace);
-    return DatastoreV1.Mutation.newBuilder().addDelete(mutationKey).build();
+  public Mutation getPb(final String namespace) {
+    final com.google.datastore.v1.Key mutationKey = getKey().getPb(namespace);
+    return com.google.datastore.v1.Mutation.newBuilder().setDelete(mutationKey).build();
   }
 }

--- a/src/main/java/com/spotify/asyncdatastoreclient/Filter.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/Filter.java
@@ -16,8 +16,6 @@
 
 package com.spotify.asyncdatastoreclient;
 
-import com.google.api.services.datastore.DatastoreV1;
-
 /**
  * Represents query filter.
  *
@@ -45,32 +43,32 @@ public class Filter {
     this.value = value;
   }
 
-  DatastoreV1.Filter getPb() {
-    final DatastoreV1.PropertyFilter.Builder filter = DatastoreV1.PropertyFilter.newBuilder()
-        .setProperty(DatastoreV1.PropertyReference.newBuilder().setName(name))
-        .setValue(value.getPb());
+  com.google.datastore.v1.Filter getPb(final String namespace) {
+    final com.google.datastore.v1.PropertyFilter.Builder filter = com.google.datastore.v1.PropertyFilter.newBuilder()
+        .setProperty(com.google.datastore.v1.PropertyReference.newBuilder().setName(name))
+        .setValue(value.getPb(namespace));
     switch (op) {
       case LESS_THAN:
-        filter.setOperator(DatastoreV1.PropertyFilter.Operator.LESS_THAN);
+        filter.setOp(com.google.datastore.v1.PropertyFilter.Operator.LESS_THAN);
         break;
       case LESS_THAN_OR_EQUAL:
-        filter.setOperator(DatastoreV1.PropertyFilter.Operator.LESS_THAN_OR_EQUAL);
+        filter.setOp(com.google.datastore.v1.PropertyFilter.Operator.LESS_THAN_OR_EQUAL);
         break;
       case GREATER_THAN:
-        filter.setOperator(DatastoreV1.PropertyFilter.Operator.GREATER_THAN);
+        filter.setOp(com.google.datastore.v1.PropertyFilter.Operator.GREATER_THAN);
         break;
       case GREATER_THAN_OR_EQUAL:
-        filter.setOperator(DatastoreV1.PropertyFilter.Operator.GREATER_THAN_OR_EQUAL);
+        filter.setOp(com.google.datastore.v1.PropertyFilter.Operator.GREATER_THAN_OR_EQUAL);
         break;
       case EQUAL:
-        filter.setOperator(DatastoreV1.PropertyFilter.Operator.EQUAL);
+        filter.setOp(com.google.datastore.v1.PropertyFilter.Operator.EQUAL);
         break;
       case HAS_ANCESTOR:
-        filter.setOperator(DatastoreV1.PropertyFilter.Operator.HAS_ANCESTOR);
+        filter.setOp(com.google.datastore.v1.PropertyFilter.Operator.HAS_ANCESTOR);
         break;
       default:
         break;
     }
-    return DatastoreV1.Filter.newBuilder().setPropertyFilter(filter).build();
+    return com.google.datastore.v1.Filter.newBuilder().setPropertyFilter(filter).build();
   }
 }

--- a/src/main/java/com/spotify/asyncdatastoreclient/Group.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/Group.java
@@ -16,8 +16,6 @@
 
 package com.spotify.asyncdatastoreclient;
 
-import com.google.api.services.datastore.DatastoreV1;
-
 /**
  * Represents query group by.
  *
@@ -31,8 +29,8 @@ public class Group {
     this.name = name;
   }
 
-  DatastoreV1.PropertyReference getPb() {
-    return DatastoreV1.PropertyReference.newBuilder()
+  com.google.datastore.v1.PropertyReference getPb() {
+    return com.google.datastore.v1.PropertyReference.newBuilder()
         .setName(name)
         .build();
   }

--- a/src/main/java/com/spotify/asyncdatastoreclient/Insert.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/Insert.java
@@ -16,7 +16,7 @@
 
 package com.spotify.asyncdatastoreclient;
 
-import com.google.api.services.datastore.DatastoreV1;
+import com.google.datastore.v1.Mutation;
 
 import java.util.List;
 
@@ -77,13 +77,10 @@ public class Insert extends KeyedStatement implements MutationStatement {
   }
 
   @Override
-  public DatastoreV1.Mutation getPb(final String namespace) {
-    final DatastoreV1.Mutation.Builder mutation = DatastoreV1.Mutation.newBuilder();
-    if (getKey().isComplete()) {
-      mutation.addInsert(entity.build().getPb(namespace));
-    } else {
-      mutation.addInsertAutoId(entity.build().getPb(namespace));
-    }
-    return mutation.build();
+  public Mutation getPb(final String namespace) {
+    final com.google.datastore.v1.Mutation.Builder mutation =
+      com.google.datastore.v1.Mutation.newBuilder();
+
+    return mutation.setInsert(entity.build().getPb(namespace)).build();
   }
 }

--- a/src/main/java/com/spotify/asyncdatastoreclient/MutationStatement.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/MutationStatement.java
@@ -16,7 +16,7 @@
 
 package com.spotify.asyncdatastoreclient;
 
-import com.google.api.services.datastore.DatastoreV1;
+import com.google.datastore.v1.Mutation;
 
 /**
  * A mutation statement.
@@ -25,6 +25,6 @@ import com.google.api.services.datastore.DatastoreV1;
  */
 public interface MutationStatement extends Statement {
 
-  DatastoreV1.Mutation getPb(String namespace);
+  Mutation getPb(final String namespace);
 
 }

--- a/src/main/java/com/spotify/asyncdatastoreclient/Order.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/Order.java
@@ -16,8 +16,6 @@
 
 package com.spotify.asyncdatastoreclient;
 
-import com.google.api.services.datastore.DatastoreV1;
-
 /**
  * Represents query order.
  *
@@ -39,13 +37,13 @@ public class Order {
     this.dir = dir;
   }
 
-  DatastoreV1.PropertyOrder getPb() {
-    final DatastoreV1.PropertyOrder.Builder order = DatastoreV1.PropertyOrder.newBuilder()
-        .setProperty(DatastoreV1.PropertyReference.newBuilder().setName(name));
+  com.google.datastore.v1.PropertyOrder getPb() {
+    final com.google.datastore.v1.PropertyOrder.Builder order = com.google.datastore.v1.PropertyOrder.newBuilder()
+        .setProperty(com.google.datastore.v1.PropertyReference.newBuilder().setName(name));
     if (dir == Direction.ASCENDING) {
-      order.setDirection(DatastoreV1.PropertyOrder.Direction.ASCENDING);
+      order.setDirection(com.google.datastore.v1.PropertyOrder.Direction.ASCENDING);
     } else {
-      order.setDirection(DatastoreV1.PropertyOrder.Direction.DESCENDING);
+      order.setDirection(com.google.datastore.v1.PropertyOrder.Direction.DESCENDING);
     }
     return order.build();
   }

--- a/src/main/java/com/spotify/asyncdatastoreclient/QueryResult.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/QueryResult.java
@@ -16,7 +16,6 @@
 
 package com.spotify.asyncdatastoreclient;
 
-import com.google.api.services.datastore.DatastoreV1;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.protobuf.ByteString;
@@ -45,20 +44,20 @@ public final class QueryResult implements Result, Iterable<Entity> {
     this.cursor = cursor;
   }
 
-  static QueryResult build(final DatastoreV1.LookupResponse response) {
+  static QueryResult build(final com.google.datastore.v1.LookupResponse response) {
     return new QueryResult(ImmutableList.copyOf(
         response.getFoundList().stream()
             .map(entity -> Entity.builder(entity.getEntity()).build())
             .collect(Collectors.toList())));
   }
 
-  static QueryResult build(final DatastoreV1.RunQueryResponse response) {
-    final DatastoreV1.QueryResultBatch batch = response.getBatch();
+  static QueryResult build(final com.google.datastore.v1.RunQueryResponse response) {
+    final com.google.datastore.v1.QueryResultBatch batch = response.getBatch();
     return new QueryResult(ImmutableList.copyOf(
-        batch.getEntityResultList().stream()
+        response.getBatch().getEntityResultsList().stream()
             .map(entity -> Entity.builder(entity.getEntity()).build())
             .collect(Collectors.toList())),
-                           batch.hasEndCursor() ? batch.getEndCursor() : null);
+        batch.getEndCursor());
   }
 
   /**

--- a/src/main/java/com/spotify/asyncdatastoreclient/RollbackResult.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/RollbackResult.java
@@ -16,8 +16,6 @@
 
 package com.spotify.asyncdatastoreclient;
 
-import com.google.api.services.datastore.DatastoreV1;
-
 /**
  * A rollback result.
  *
@@ -27,7 +25,7 @@ public final class RollbackResult implements Result {
 
   private RollbackResult() {}
 
-  static RollbackResult build(final DatastoreV1.RollbackResponse response) {
+  static RollbackResult build(final com.google.datastore.v1.RollbackResponse response) {
     return new RollbackResult();
   }
 

--- a/src/main/java/com/spotify/asyncdatastoreclient/TransactionResult.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/TransactionResult.java
@@ -16,7 +16,6 @@
 
 package com.spotify.asyncdatastoreclient;
 
-import com.google.api.services.datastore.DatastoreV1;
 import com.google.protobuf.ByteString;
 
 /**
@@ -32,8 +31,8 @@ public final class TransactionResult implements Result {
     this.transaction = transaction;
   }
 
-  static TransactionResult build(final DatastoreV1.BeginTransactionResponse response) {
-    return response.hasTransaction() ? new TransactionResult(response.getTransaction()) : build();
+  static TransactionResult build(final com.google.datastore.v1.BeginTransactionResponse response) {
+    return new TransactionResult(response.getTransaction());
   }
 
   /**

--- a/src/main/java/com/spotify/asyncdatastoreclient/Update.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/Update.java
@@ -16,7 +16,7 @@
 
 package com.spotify.asyncdatastoreclient;
 
-import com.google.api.services.datastore.DatastoreV1;
+import com.google.datastore.v1.Mutation;
 
 import java.util.List;
 
@@ -104,12 +104,13 @@ public class Update extends KeyedStatement implements MutationStatement {
   }
 
   @Override
-  public DatastoreV1.Mutation getPb(final String namespace) {
-    final DatastoreV1.Mutation.Builder mutation = DatastoreV1.Mutation.newBuilder();
+  public Mutation getPb(final String namespace) {
+    final com.google.datastore.v1.Mutation.Builder mutation =
+      com.google.datastore.v1.Mutation.newBuilder();
     if (upsert) {
-      mutation.addUpsert(entity.build().getPb(namespace));
+      mutation.setUpsert(entity.build().getPb(namespace));
     } else {
-      mutation.addUpdate(entity.build().getPb(namespace));
+      mutation.setUpdate(entity.build().getPb(namespace));
     }
     return mutation.build();
   }

--- a/src/main/java/com/spotify/asyncdatastoreclient/example/Example.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/example/Example.java
@@ -16,10 +16,9 @@
 
 package com.spotify.asyncdatastoreclient.example;
 
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.client.util.Lists;
-import com.google.api.services.datastore.client.DatastoreHelper;
 import com.google.common.base.Throwables;
-
 import com.spotify.asyncdatastoreclient.Batch;
 import com.spotify.asyncdatastoreclient.Datastore;
 import com.spotify.asyncdatastoreclient.DatastoreConfig;
@@ -116,9 +115,9 @@ public final class Example {
         .requestTimeout(1000)
         .maxConnections(5)
         .requestRetry(3)
-        .dataset("my-dataset")
+        .project("my-dataset")
         .namespace("my-namespace")
-        .credential(DatastoreHelper.getComputeEngineCredential())
+        .credential(GoogleCredential.getApplicationDefault())
         .build();
 
     final Datastore datastore = Datastore.create(config);

--- a/src/main/java/com/spotify/asyncdatastoreclient/example/ExampleAsync.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/example/ExampleAsync.java
@@ -16,12 +16,11 @@
 
 package com.spotify.asyncdatastoreclient.example;
 
-import com.google.api.services.datastore.client.DatastoreHelper;
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-
 import com.spotify.asyncdatastoreclient.Batch;
 import com.spotify.asyncdatastoreclient.Datastore;
 import com.spotify.asyncdatastoreclient.DatastoreConfig;
@@ -96,9 +95,9 @@ public final class ExampleAsync {
         .requestTimeout(1000)
         .maxConnections(5)
         .requestRetry(3)
-        .dataset("my-dataset")
+        .project("my-dataset")
         .namespace("my-namespace")
-        .credential(DatastoreHelper.getComputeEngineCredential())
+        .credential(GoogleCredential.getApplicationDefault())
         .build();
 
     final Datastore datastore = Datastore.create(config);

--- a/src/test/java/com/spotify/asyncdatastoreclient/DatastoreTest.java
+++ b/src/test/java/com/spotify/asyncdatastoreclient/DatastoreTest.java
@@ -16,21 +16,21 @@
 
 package com.spotify.asyncdatastoreclient;
 
-import com.google.api.services.datastore.client.DatastoreHelper;
-
-import org.junit.Before;
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import org.junit.After;
+import org.junit.Before;
 
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
-import java.security.GeneralSecurityException;
 
 public abstract class DatastoreTest {
 
   public static final String DATASTORE_HOST = System.getProperty("host", "http://localhost:8080");
-  public static final String DATASET_ID = System.getProperty("dataset", "async-test");
+  public static final String PROJECT = System.getProperty("dataset", "async-test");
   public static final String NAMESPACE = System.getProperty("namespace", "test");
-  public static final String ACCOUNT = System.getProperty("account");
   public static final String KEY_PATH = System.getProperty("keypath");
+  public static final String VERSION = System.getProperty("version", "v1beta3");
 
   protected static Datastore datastore;
 
@@ -46,21 +46,20 @@ public abstract class DatastoreTest {
         .requestTimeout(1000)
         .maxConnections(5)
         .requestRetry(3)
+        .version(VERSION)
         .host(DATASTORE_HOST)
-        .dataset(DATASET_ID);
+        .project(PROJECT);
 
     if (NAMESPACE != null) {
       config.namespace(NAMESPACE);
     }
 
-    if (ACCOUNT != null && KEY_PATH != null) {
+    if (KEY_PATH != null) {
       try {
-        config.credential(DatastoreHelper.getServiceAccountCredential(ACCOUNT, KEY_PATH));
-      } catch (final GeneralSecurityException e) {
-        System.err.println("Security error connecting to the datastore: " + e.getMessage());
-        System.exit(1);
-      } catch (final IOException e) {
-        System.err.println("I/O error connecting to the datastore: " + e.getMessage());
+        FileInputStream creds = new FileInputStream(new File(KEY_PATH));
+        config.credential(GoogleCredential.fromStream(creds).createScoped(DatastoreConfig.SCOPES));
+      }  catch (final IOException e) {
+        System.err.println("Failed to load credentials " + e.getMessage());
         System.exit(1);
       }
     }

--- a/src/test/java/com/spotify/asyncdatastoreclient/InsertTest.java
+++ b/src/test/java/com/spotify/asyncdatastoreclient/InsertTest.java
@@ -22,7 +22,6 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.ByteString;
-
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 

--- a/src/test/java/com/spotify/asyncdatastoreclient/KeyTest.java
+++ b/src/test/java/com/spotify/asyncdatastoreclient/KeyTest.java
@@ -16,17 +16,11 @@
 
 package com.spotify.asyncdatastoreclient;
 
-import com.google.api.services.datastore.DatastoreV1;
-
 import org.junit.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.*;
 
 public class KeyTest {
 
@@ -85,8 +79,8 @@ public class KeyTest {
     assertEquals("fred", test16.getPath().get(0).getName());
     assertTrue(test16.isComplete());
 
-    final DatastoreV1.Key test17Pb = DatastoreV1.Key.newBuilder()
-        .addPathElement(DatastoreV1.Key.PathElement.newBuilder().setKind("employee").setName("fred")).build();
+    final  com.google.datastore.v1.Key test17Pb =  com.google.datastore.v1.Key.newBuilder()
+        .addPath(com.google.datastore.v1.Key.PathElement.newBuilder().setKind("employee").setName("fred")).build();
     final Key test17 = Key.builder(test17Pb).build();
     assertEquals("employee", test17.getPath().get(0).getKind());
     assertEquals("fred", test17.getPath().get(0).getName());
@@ -143,7 +137,7 @@ public class KeyTest {
   @Test
   public void testGetPb() throws Exception {
     final Key test1 = Key.builder().build();
-    assertEquals("namespace", test1.getPb("namespace").getPartitionId().getNamespace());
+    assertEquals("namespace", test1.getPb("namespace").getPartitionId().getNamespaceId());
 
     // Passing in null should not throw exception
     assertNotNull(test1.getPb(null));

--- a/src/test/java/com/spotify/asyncdatastoreclient/QueryTest.java
+++ b/src/test/java/com/spotify/asyncdatastoreclient/QueryTest.java
@@ -326,6 +326,7 @@ public class QueryTest extends DatastoreTest {
     assertEquals(10, entities.size());
   }
 
+
   @Test
   public void testQueryKeyFilter() throws Exception {
     final Key record = Key.builder("record", 2345678L).build();

--- a/src/test/java/com/spotify/asyncdatastoreclient/TransactionTest.java
+++ b/src/test/java/com/spotify/asyncdatastoreclient/TransactionTest.java
@@ -53,23 +53,6 @@ public class TransactionTest extends DatastoreTest {
   }
 
   @Test
-  public void testInsertWithSerializable() throws Exception {
-    final TransactionResult txn = datastore.transaction(Datastore.IsolationLevel.SERIALIZABLE);
-
-    final Insert insert = QueryBuilder.insert("employee")
-        .value("fullname", "Fred Blinge")
-        .value("age", 40, false);
-
-    final MutationResult insertResult = datastore.execute(insert, txn);
-
-    final KeyQuery get = QueryBuilder.query(insertResult.getInsertKey());
-    final QueryResult getResult = datastore.execute(get);
-
-    assertEquals("Fred Blinge", getResult.getEntity().getString("fullname"));
-    assertEquals(40, getResult.getEntity().getInteger("age").intValue());
-  }
-
-  @Test
   public void testInsertAsync() throws Exception {
     final ListenableFuture<TransactionResult> txn = datastore.transactionAsync();
 

--- a/src/test/java/com/spotify/asyncdatastoreclient/ValueTest.java
+++ b/src/test/java/com/spotify/asyncdatastoreclient/ValueTest.java
@@ -132,7 +132,7 @@ public class ValueTest {
     final Value value2 = Value.from("test").build();
     assertEquals(value1.hashCode(), value2.hashCode());
 
-    final Value value3 = Value.from("test").build();
+    final Value value3 = Value.from("test").indexed(false).build();
     final Value value4 = Value.from("test").indexed(true).build();
     assertNotEquals(value3.hashCode(), value4.hashCode());
   }


### PR DESCRIPTION
Google will deprecate v1beta2, the version that  is currently used by this library, on September 30th, which will make the library unusable. 

This patch adds support for the v1 API.

https://cloud.google.com/datastore/release-notes

