### PR TITLE
Ensure token is properly initialized when using local credentials

### DIFF
--- a/src/main/java/com/spotify/asyncdatastoreclient/DatastoreImpl.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/DatastoreImpl.java
@@ -106,8 +106,10 @@ final class DatastoreImpl implements Datastore {
     final Credential credential = config.getCredential();
     final Long expiresIn = credential.getExpiresInSeconds();
 
-    // trigger refresh if token is about to expire
-    if (credential.getAccessToken() == null || expiresIn != null && expiresIn <= 60) {
+    // trigger refresh if token null or is about to expire
+    if (this.accessToken == null
+        || credential.getAccessToken() == null
+        || expiresIn != null && expiresIn <= 60) {
       try {
         credential.refreshToken();
         final String accessTokenLocal = credential.getAccessToken();


### PR DESCRIPTION
When using a user's local credentials, the async client never reads the access token,
causing authentication failures when trying to connect to datastore. This works
when using service accounts. The difference is that for user credentials, Google's
auth library initializes the access token for you[1], but does not with service
accounts[2].

DatastoreImpl sets up authentication correctly only if the credential's access token
is null[3], but for user credentials, the token will never be null.

This PR makes it so DatastoreImpl now handles this case correctly.

[1] https://github.com/google/google-api-java-client/blob/73337e927fd1bac1946c83e0a876d67620d80b00/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2/GoogleCredential.java#L814
[2] https://github.com/google/google-api-java-client/blob/1.23.0/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2/GoogleCredential.java#L852
[3] https://github.com/spotify/async-datastore-client/blame/master/src/main/java/com/spotify/asyncdatastoreclient/DatastoreImpl.java#L110