### PR TITLE
Update tests for new status codes returned by emulator

### DIFF
--- a/src/test/java/com/spotify/asyncdatastoreclient/InsertTest.java
+++ b/src/test/java/com/spotify/asyncdatastoreclient/InsertTest.java
@@ -126,7 +126,7 @@ public class InsertTest extends DatastoreTest {
       datastore.execute(insertSecond);
       fail("Expected DatastoreException exception.");
     } catch (final DatastoreException e) {
-      assertEquals(400, e.getStatusCode().intValue()); // bad request
+      assertEquals(409, e.getStatusCode().intValue()); // conflict
     }
   }
 

--- a/src/test/java/com/spotify/asyncdatastoreclient/UpdateTest.java
+++ b/src/test/java/com/spotify/asyncdatastoreclient/UpdateTest.java
@@ -55,7 +55,7 @@ public class UpdateTest extends DatastoreTest {
       datastore.execute(update);
       fail("Expected DatastoreException exception.");
     } catch (final DatastoreException e) {
-      assertEquals(400, e.getStatusCode().intValue()); // bad request
+      assertEquals(404, e.getStatusCode().intValue()); // not found
     }
   }
 


### PR DESCRIPTION
Instead of 400, the datastore emulator now returns more specific codes for these cases:
* Insert fails because items already exists returns 409
* Update fails because items doesn't exists returns 404