### PR TITLE
Stop using deprecated Guava methods so that it will be binary compatible with Guava 26.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>23.0</version>
+            <version>26.0-jre</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud.datastore</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>26.0-jre</version>
+            <version>23.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud.datastore</groupId>

--- a/src/main/java/com/spotify/asyncdatastoreclient/DatastoreImpl.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/DatastoreImpl.java
@@ -22,6 +22,7 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.datastore.v1.AllocateIdsRequest;
 import com.google.datastore.v1.AllocateIdsResponse;
 import com.google.datastore.v1.BeginTransactionRequest;
@@ -164,7 +165,7 @@ final class DatastoreImpl implements Datastore {
       }
       final BeginTransactionResponse transaction = BeginTransactionResponse.parseFrom(streamResponse(response));
       return Futures.immediateFuture(TransactionResult.build(transaction));
-    });
+    }, MoreExecutors.directExecutor());
   }
 
   @Override
@@ -182,14 +183,14 @@ final class DatastoreImpl implements Datastore {
       final RollbackRequest.Builder request = RollbackRequest.newBuilder();
       final ProtoHttpContent payload = new ProtoHttpContent(request.build());
       return ListenableFutureAdapter.asGuavaFuture(prepareRequest("rollback", payload).execute());
-    });
+    }, MoreExecutors.directExecutor());
     return Futures.transformAsync(httpResponse, response -> {
       if (!isSuccessful(response.getStatusCode())) {
         throw new DatastoreException(response.getStatusCode(), response.getResponseBody());
       }
       final RollbackResponse rollback = RollbackResponse.parseFrom(streamResponse(response));
       return Futures.immediateFuture(RollbackResult.build(rollback));
-    });
+    }, MoreExecutors.directExecutor());
   }
 
   @Override
@@ -224,7 +225,7 @@ final class DatastoreImpl implements Datastore {
       }
       final AllocateIdsResponse allocate = AllocateIdsResponse.parseFrom(streamResponse(response));
       return Futures.immediateFuture(AllocateIdsResult.build(allocate));
-    });
+    }, MoreExecutors.directExecutor());
   }
 
   @Override
@@ -274,14 +275,14 @@ final class DatastoreImpl implements Datastore {
       }
       final ProtoHttpContent payload = new ProtoHttpContent(request.build());
       return ListenableFutureAdapter.asGuavaFuture(prepareRequest("lookup", payload).execute());
-    });
+    }, MoreExecutors.directExecutor());
     return Futures.transformAsync(httpResponse, response -> {
       if (!isSuccessful(response.getStatusCode())) {
         throw new DatastoreException(response.getStatusCode(), response.getResponseBody());
       }
       final LookupResponse query = LookupResponse.parseFrom(streamResponse(response));
       return Futures.immediateFuture(QueryResult.build(query));
-    });
+    }, MoreExecutors.directExecutor());
   }
 
   @Override
@@ -344,14 +345,14 @@ final class DatastoreImpl implements Datastore {
       }
       final ProtoHttpContent payload = new ProtoHttpContent(request.build());
       return ListenableFutureAdapter.asGuavaFuture(prepareRequest("commit", payload).execute());
-    });
+    }, MoreExecutors.directExecutor());
     return Futures.transformAsync(httpResponse, response -> {
       if (!isSuccessful(response.getStatusCode())) {
         throw new DatastoreException(response.getStatusCode(), response.getResponseBody());
       }
       final CommitResponse commit = CommitResponse.parseFrom(streamResponse(response));
       return Futures.immediateFuture(MutationResult.build(commit));
-    });
+    }, MoreExecutors.directExecutor());
   }
 
   @Override
@@ -384,13 +385,13 @@ final class DatastoreImpl implements Datastore {
       }
       final ProtoHttpContent payload = new ProtoHttpContent(request.build());
       return ListenableFutureAdapter.asGuavaFuture(prepareRequest("runQuery", payload).execute());
-    });
+    }, MoreExecutors.directExecutor());
     return Futures.transformAsync(httpResponse, response -> {
       if (!isSuccessful(response.getStatusCode())) {
         throw new DatastoreException(response.getStatusCode(), response.getResponseBody());
       }
       final RunQueryResponse query = RunQueryResponse.parseFrom(streamResponse(response));
       return Futures.immediateFuture(QueryResult.build(query));
-    });
+    }, MoreExecutors.directExecutor());
   }
 }

--- a/src/main/java/com/spotify/asyncdatastoreclient/example/ExampleAsync.java
+++ b/src/main/java/com/spotify/asyncdatastoreclient/example/ExampleAsync.java
@@ -21,6 +21,7 @@ import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.spotify.asyncdatastoreclient.Batch;
 import com.spotify.asyncdatastoreclient.Datastore;
 import com.spotify.asyncdatastoreclient.DatastoreConfig;
@@ -71,7 +72,7 @@ public final class ExampleAsync {
           .value("inserted", new Date())
           .value("age", 40);
       return datastore.executeAsync(insert);
-    });
+    }, MoreExecutors.directExecutor());
   }
 
   private static ListenableFuture<QueryResult> queryData(final Datastore datastore) {
@@ -108,7 +109,7 @@ public final class ExampleAsync {
     final ListenableFuture<List<Object>> addBoth = Futures.allAsList(addFirst, addSecond);
 
     // Query the entities we've just inserted
-    final ListenableFuture<QueryResult> query = Futures.transformAsync(addBoth, result -> queryData(datastore));
+    final ListenableFuture<QueryResult> query = Futures.transformAsync(addBoth, result -> queryData(datastore), MoreExecutors.directExecutor());
 
     // Print the query results before clean up
     final ListenableFuture<MutationResult> delete = Futures.transformAsync(query, result -> {
@@ -117,7 +118,7 @@ public final class ExampleAsync {
         System.out.println("Employee age: " + entity.getInteger("age"));
       }
       return deleteData(datastore);
-    });
+    }, MoreExecutors.directExecutor());
 
     Futures.addCallback(delete, new FutureCallback<MutationResult>() {
       @Override
@@ -129,6 +130,6 @@ public final class ExampleAsync {
       public void onFailure(final Throwable throwable) {
         System.err.println("Storage exception: " + Throwables.getRootCause(throwable).getMessage());
       }
-    });
+    }, MoreExecutors.directExecutor());
   }
 }

--- a/src/test/java/com/spotify/asyncdatastoreclient/InsertTest.java
+++ b/src/test/java/com/spotify/asyncdatastoreclient/InsertTest.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.ByteString;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -77,7 +78,7 @@ public class InsertTest extends DatastoreTest {
       public void onFailure(final Throwable throwable) {
         fail(Throwables.getRootCause(throwable).getMessage());
       }
-    });
+    }, MoreExecutors.directExecutor());
   }
 
   @Test

--- a/src/test/java/com/spotify/asyncdatastoreclient/QueryTest.java
+++ b/src/test/java/com/spotify/asyncdatastoreclient/QueryTest.java
@@ -22,6 +22,7 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 
+import com.google.common.util.concurrent.MoreExecutors;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -476,7 +477,7 @@ public class QueryTest extends DatastoreTest {
       public void onFailure(final Throwable throwable) {
         fail(Throwables.getRootCause(throwable).getMessage());
       }
-    });
+    }, MoreExecutors.directExecutor());
   }
 
   @Test

--- a/src/test/java/com/spotify/asyncdatastoreclient/TransactionTest.java
+++ b/src/test/java/com/spotify/asyncdatastoreclient/TransactionTest.java
@@ -21,6 +21,7 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 
+import com.google.common.util.concurrent.MoreExecutors;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -65,7 +66,7 @@ public class TransactionTest extends DatastoreTest {
     final ListenableFuture<QueryResult> getResult = Futures.transformAsync(insertResult, mutationResult -> {
       final KeyQuery get = QueryBuilder.query(mutationResult.getInsertKey());
       return datastore.executeAsync(get);
-    });
+    }, MoreExecutors.directExecutor());
 
     Futures.addCallback(getResult, new FutureCallback<QueryResult>() {
       @Override
@@ -78,7 +79,7 @@ public class TransactionTest extends DatastoreTest {
       public void onFailure(final Throwable throwable) {
         fail(Throwables.getRootCause(throwable).getMessage());
       }
-    });
+    }, MoreExecutors.directExecutor());
   }
 
   @Test


### PR DESCRIPTION
The tests pass with both guava 23.0 and 26.0-jre.